### PR TITLE
[Bug] Avoid a Runtime Notice

### DIFF
--- a/Factory/QueueFactory.php
+++ b/Factory/QueueFactory.php
@@ -47,6 +47,8 @@ class QueueFactory implements QueueFactoryInterface
      */
     public static function getNameFromUrl($url)
     {
-        return trim(array_pop(explode('/', $url)));
+        $exploded = explode('/', $url);
+
+        return trim(array_pop($exploded));
     }
 }


### PR DESCRIPTION
explode() function in array_pop causes Runtime Notice: Only variables should be passed by reference

See http://stackoverflow.com/questions/9848295/strict-standards-only-variables-should-be-passed-by-reference-error
